### PR TITLE
[TM ONLY] Un-Defines Primogen Domain

### DIFF
--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/banu_haqim.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/banu_haqim.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/primogen_banu
 	title = JOB_PRIMOGEN_BANU_HAQIM
-	description = "Offer your infinite knowledge to Prince of the City, while overseeing the Banu Haqim in the city. Monitor their contracts and ensure they remain true to the ways of the Clan. You have an official cover with the Police Department as a local civilian consultant, ensure things run smoothly, on either end."
+	description = "Offer your infinite knowledge to Prince of the City, while overseeing the Banu Haqim in the city. Monitor their contracts and ensure they remain true to the ways of the Clan."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CAMARILLA
 	total_positions = 1

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/lasombra.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/lasombra.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/primogen_lasombra
 	title = JOB_PRIMOGEN_LASOMBRA
-	description = "Offer your infinite knowledge to Prince of the City. Monitor those of your Clan and your lesser cousins, while holding a Court of Blood as need be, for all it takes for the Camarilla to turn on you is one mistake. You and Your Clan were given a domain in the local Church and in the vicinity of a swarm of Lupines, keep matters under control."
+	description = "Offer your infinite knowledge to Prince of the City. Monitor those of your Clan and your lesser cousins, while holding a Court of Blood as need be, for all it takes for the Camarilla to turn on you is one mistake."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CAMARILLA
 	total_positions = 1
@@ -18,7 +18,6 @@
 
 	display_order = JOB_DISPLAY_ORDER_LASOMBRA
 	departments_list = list(
-		/datum/job_department/church,
 		/datum/job_department/camarilla,
 	)
 

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/malkavian.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/malkavian.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/primogen_malkavian
 	title = JOB_PRIMOGEN_MALKAVIAN
-	description = "Offer your infinite knowledge to Prince of the City. You likely have a hold over the local hospital, make good use of it and ensure the blood bags remain available."
+	description = "Offer your infinite knowledge to Prince of the City. Uphold clan interests. Lead the children of the moon and shattered mirror."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CAMARILLA
 	total_positions = 1
@@ -18,7 +18,6 @@
 
 	display_order = JOB_DISPLAY_ORDER_MALKAVIAN
 	departments_list = list(
-		/datum/job_department/clinic,
 		/datum/job_department/camarilla,
 	)
 

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/nosferatu.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/nosferatu.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/primogen_nosferatu
 	title = JOB_PRIMOGEN_NOSFERATU
-	description = "Offer your infinite knowledge to Prince of the City, and run the warren, your domain watches over the sewers."
+	description = "Offer your infinite knowledge to Prince of the City. Manage what's left of your Warrens. Keep your clan interests in mind."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CAMARILLA
 	total_positions = 1
@@ -19,7 +19,6 @@
 	display_order = JOB_DISPLAY_ORDER_NOSFERATU
 	departments_list = list(
 		/datum/job_department/camarilla,
-		/datum/job_department/city_services
 	)
 
 	minimal_generation = 12

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/toreador.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/toreador.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/primogen_toreador
 	title = JOB_PRIMOGEN_TOREADOR
-	description = "Offer your infinite knowledge to Prince of the City. Take care of the Strip Club and its Elysium, for it is your domain and a social center within the city."
+	description = "Offer your infinite knowledge to Prince of the City. Keep clan interests in mind."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CAMARILLA
 	total_positions = 1
@@ -18,7 +18,6 @@
 
 	display_order = JOB_DISPLAY_ORDER_TOREADOR
 	departments_list = list(
-		/datum/job_department/strip_club,
 		/datum/job_department/camarilla,
 	)
 

--- a/modular_darkpack/modules/jobs/code/camarilla/primogens/ventrue.dm
+++ b/modular_darkpack/modules/jobs/code/camarilla/primogens/ventrue.dm
@@ -1,6 +1,6 @@
 /datum/job/vampire/primogen_ventrue
 	title = JOB_PRIMOGEN_VENTRUE
-	description = "Offer your infinite knowledge to Prince of the City. Maintain the local Jazz Club, in front of the Tower, and its Elysium."
+	description = "Offer your infinite knowledge to Prince of the City. Uphold Clan interests and look out for prospective protege for it."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	faction = FACTION_CAMARILLA
 	total_positions = 1


### PR DESCRIPTION

## About The Pull Request

pulls back TFN upstream changes that aren't in line with server lore, getting primogens out of departments other than Camarilla and changing their roundstart text to not lead them to thinking they're afforded domain by default

## Why It's Good For The Game

people keep assuming the primogens hold domain over businesses on the map by default when that's not the case
also i was told i could do this, smiles
<img width="1134" height="182" alt="image" src="https://github.com/user-attachments/assets/d235c478-6561-46b1-987a-06d39b7f98f9" />

## Changelog

:cl:
code: changed primogen departments and roundstart text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
