### PR TITLE
Strip club fixes 

### DIFF
--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -13062,7 +13062,10 @@
 /turf/open/floor/city/factory,
 /area/vtm/interior/radio)
 "hFE" = (
-/obj/machinery/vending/boozeomat/private,
+/obj/machinery/vending/boozeomat/private{
+	density = 0;
+	pixel_x = 32
+	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "hFY" = (
@@ -13519,8 +13522,11 @@
 /turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/millennium_tower/f4)
 "hSC" = (
-/obj/effect/decal/wallpaper/red,
-/turf/closed/wall/vampwall/bar,
+/obj/structure/vampdoor{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/door/access/strip,
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "hSG" = (
 /obj/effect/landmark/npcwall,
@@ -17649,8 +17655,8 @@
 "klw" = (
 /obj/structure/mop_bucket,
 /obj/item/reagent_containers/cup/bucket,
-/obj/item/mop,
 /obj/item/pushbroom,
+/obj/item/mop,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "klR" = (
@@ -26656,8 +26662,8 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "pDq" = (
-/obj/effect/mapping_helpers/door/access/daughters,
 /obj/structure/vampdoor,
+/obj/effect/mapping_helpers/door/access/strip,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "pDt" = (
@@ -40689,8 +40695,10 @@
 /obj/item/clothing/under/vampire/toreador,
 /obj/item/clothing/under/vampire/toreador/female,
 /obj/item/clothing/under/vampire/toreador/female,
-/obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
-/obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
+/obj/item/clothing/head/costume/kitty,
+/obj/item/clothing/head/costume/kitty,
+/obj/item/clothing/head/costume/rabbitears,
+/obj/item/clothing/head/costume/rabbitears,
 /turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "xKY" = (
@@ -45004,7 +45012,7 @@ vWN
 vWN
 vWN
 vWN
-vWN
+urj
 nDN
 cgD
 rVC
@@ -45970,7 +45978,7 @@ hrk
 jzc
 iME
 wGX
-ppv
+hFE
 bfQ
 rwK
 nOx
@@ -46077,9 +46085,9 @@ hrk
 hrk
 hrk
 vWN
-hFE
+vWN
 urj
-eHp
+hSC
 vWN
 vWN
 vWN
@@ -46188,7 +46196,7 @@ sQl
 iNE
 ppv
 ppv
-vWN
+klw
 vWN
 hUM
 hUM
@@ -46280,14 +46288,14 @@ hUM
 hUM
 hUM
 hUM
-hSC
+urj
 sCK
 ukg
-qQr
-qQr
-qQr
-qQr
-tjZ
+vWN
+vWN
+vWN
+vWN
+urj
 sCK
 ukg
 vWN
@@ -46295,7 +46303,7 @@ gML
 xtA
 ppv
 ppv
-klw
+ppv
 vWN
 hUM
 hUM
@@ -46387,7 +46395,7 @@ hUM
 hUM
 hUM
 hUM
-hSC
+urj
 gtt
 wzK
 dKw
@@ -46494,7 +46502,7 @@ hUM
 hUM
 hUM
 hUM
-hSC
+urj
 hVZ
 wzK
 wzK
@@ -46601,7 +46609,7 @@ hUM
 hUM
 hUM
 hUM
-hSC
+urj
 fZG
 tWI
 fVu

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -7823,7 +7823,7 @@
 /obj/structure/vampdoor{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/door/access/daughters,
+/obj/effect/mapping_helpers/door/access/strip,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "eHq" = (
@@ -13153,7 +13153,7 @@
 /area/vtm/interior/millennium_tower/f2)
 "hIE" = (
 /obj/structure/vampdoor,
-/obj/effect/mapping_helpers/door/access/daughters,
+/obj/effect/mapping_helpers/door/access/strip,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/strip)
 "hIG" = (
@@ -13521,13 +13521,6 @@
 /obj/structure/hedge,
 /turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/millennium_tower/f4)
-"hSC" = (
-/obj/structure/vampdoor{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/door/access/strip,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/strip)
 "hSG" = (
 /obj/effect/landmark/npcwall,
 /obj/effect/turf_decal/bordur/corner,
@@ -17652,13 +17645,6 @@
 	},
 /turf/open/floor/wood/herring,
 /area/vtm/interior/voivodate)
-"klw" = (
-/obj/structure/mop_bucket,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/pushbroom,
-/obj/item/mop,
-/turf/open/floor/city/plating,
-/area/vtm/interior/strip)
 "klR" = (
 /obj/structure/table/wood,
 /obj/item/folder/red{
@@ -26662,9 +26648,11 @@
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "pDq" = (
-/obj/structure/vampdoor,
-/obj/effect/mapping_helpers/door/access/strip,
-/turf/open/floor/city/plating_mono,
+/obj/structure/mop_bucket,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/pushbroom,
+/obj/item/mop,
+/turf/open/floor/city/plating,
 /area/vtm/interior/strip)
 "pDt" = (
 /obj/structure/vampdoor/glass,
@@ -46087,7 +46075,7 @@ hrk
 vWN
 vWN
 urj
-hSC
+eHp
 vWN
 vWN
 vWN
@@ -46196,7 +46184,7 @@ sQl
 iNE
 ppv
 ppv
-klw
+pDq
 vWN
 hUM
 hUM
@@ -46405,7 +46393,7 @@ fxx
 wzK
 wzK
 xtC
-pDq
+hIE
 ppv
 ppv
 ppv

--- a/modular_darkpack/modules/doors/code/components/door_ownership.dm
+++ b/modular_darkpack/modules/doors/code/components/door_ownership.dm
@@ -63,7 +63,7 @@
 			ownership_question = "Is this my car?"
 			alert_title = "Vehicle"
 		if(LOCK_OWNERSHIP_APARTMENT)
-			ownership_question = "Is this my apartment?"
+			ownership_question = "Is this my apartment? (Please be courteous and only claim apartments when you need them!)"
 			alert_title = "Apartment"
 
 	var/alert = tgui_alert(human, ownership_question, alert_title, list("Yes", "No"))


### PR DESCRIPTION
## About The Pull Request

1. sets the lockable strip club doors to the actual strip club key access, and makes the back changing room not look-in-able
2. adds a little reminder when claiming doors to only claim them when you need them

## Why It's Good For The Game

1. makes the strip club a little more functional as a strip club
2. at least nudges players toward not just preemptively snatching up houses they aren't even going to use

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: small strip club tweaks
code: small courtesy reminder when claiming doors
/:cl:

