### PR TITLE
remove antag datum from sabbat

### DIFF
--- a/modular_darkpack/modules/jobs/code/sabbat/ductus.dm
+++ b/modular_darkpack/modules/jobs/code/sabbat/ductus.dm
@@ -27,8 +27,9 @@
 	r_pocket = /obj/item/vamp/keys/sabbat
 	uses_default_clan_clothes = TRUE
 	backpack_contents = list(/obj/item/card/credit=1)
-
+/*// APOC EDIT REMOVAL START
 /datum/outfit/job/vampire/sabbatductus/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	if(H.mind)
 		H.mind.add_antag_datum(/datum/antagonist/sabbatist/ductus)
+*/ // APOC EDIT REMOVAL END

--- a/modular_darkpack/modules/jobs/code/sabbat/pack.dm
+++ b/modular_darkpack/modules/jobs/code/sabbat/pack.dm
@@ -27,9 +27,9 @@
 	r_pocket = /obj/item/vamp/keys/sabbat
 	uses_default_clan_clothes = TRUE
 	backpack_contents = list(/obj/item/card/credit=1)
-
+/*// APOC EDIT REMOVAL START
 /datum/outfit/job/vampire/sabbatpack/pre_equip(mob/living/carbon/human/H)
 	. = ..()
 	if(H.mind)
 		H.mind.add_antag_datum(/datum/antagonist/sabbatist)
-
+*/ // APOC EDIT REMOVAL END

--- a/modular_darkpack/modules/jobs/code/sabbat/priest.dm
+++ b/modular_darkpack/modules/jobs/code/sabbat/priest.dm
@@ -27,12 +27,12 @@
 	head = /obj/item/clothing/head/vampire/noddist_mask
 	uses_default_clan_clothes = TRUE
 	backpack_contents = list(/obj/item/card/credit=1)
-
+/*// APOC EDIT REMOVAL START
 /datum/outfit/job/vampire/sabbatpriest/pre_equip(mob/living/carbon/human/H)
 	..()
 	if(H.mind)
 		H.mind.add_antag_datum(/datum/antagonist/sabbatist/priest)
-
+*/ // APOC EDIT REMOVAL END
 /datum/antagonist/sabbatist/priest
 	antag_hud_name = "ductus_priest"
 


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Sabbat no longer are assigned an antag datum
/:cl: