### PR TITLE
Millennium Tower Touch Ups and Changes

### DIFF
--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -1,4 +1,18 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aac" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 5
+	},
+/obj/structure/closet/crate/bin/undense{
+	pixel_x = 7;
+	pixel_y = 13
+	},
+/obj/structure/sink/directional/south{
+	pixel_x = -8;
+	pixel_y = 13
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "aaj" = (
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/junk,
@@ -74,6 +88,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/pacificheights)
+"acj" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "acu" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/city/plating,
@@ -1061,11 +1081,6 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
-"aIU" = (
-/obj/structure/sink/directional/south,
-/obj/structure/mirror/directional/north,
-/turf/open/floor/city/plating_stone,
-/area/vtm/interior/millennium_tower/f4)
 "aIX" = (
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/city,
@@ -2781,9 +2796,8 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/coffee)
 "bGG" = (
-/obj/effect/turf_decal/stripes/red/full,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/f4)
+/turf/open/floor/city/toilet/large,
+/area/vtm/interior/millennium_tower)
 "bGP" = (
 /obj/structure/table/wood/fancy/green,
 /obj/effect/turf_decal/siding/wood{
@@ -3226,13 +3240,9 @@
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/voivodate)
 "bUB" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/item/melee/vamp/tire,
-/obj/item/melee/vamp/tire,
-/obj/item/melee/vamp/tire,
-/turf/open/floor/plating/asphalt,
-/area/vtm/interior/millennium_tower)
+/obj/structure/vampdoor/simple,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "bUK" = (
 /obj/effect/decal/cleanable/trash,
 /obj/effect/decal/cleanable/trash,
@@ -3378,10 +3388,12 @@
 /turf/open/floor/carpet/darkpack/redsilver,
 /area/vtm/interior/millennium_tower)
 "bZr" = (
-/obj/structure/chair/darkpack/green,
-/obj/effect/decal/cleanable/trash,
+/obj/structure/chair/sofa/corp/left{
+	color = "#50C878";
+	dir = 8
+	},
 /turf/open/floor/city/plating,
-/area/vtm/interior/radio)
+/area/vtm/interior/millennium_tower)
 "bZA" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/spray/cleaner,
@@ -3548,9 +3560,11 @@
 /turf/open/floor/iron/stairs,
 /area/vtm/interior/supply)
 "cdC" = (
-/obj/structure/vampdoor/simple,
-/turf/open/floor/city/plating_stone,
-/area/vtm/interior/millennium_tower/f4)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "cdL" = (
 /obj/structure/table,
 /turf/open/floor/city/plating_stone,
@@ -3713,6 +3727,13 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/voivodate)
+"cic" = (
+/obj/structure/table/wood,
+/obj/item/newspaper{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "cie" = (
 /obj/structure/table,
 /obj/effect/decal/pallet,
@@ -3734,7 +3755,10 @@
 /turf/open/floor/wood/rough,
 /area/vtm)
 "ciD" = (
-/obj/effect/decal/cleanable/trash,
+/obj/structure/table,
+/obj/item/melee/vamp/tire,
+/obj/item/melee/vamp/tire,
+/obj/item/melee/vamp/tire,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
 "ciF" = (
@@ -4876,6 +4900,10 @@
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/city,
 /area/vtm/interior/laundromat)
+"cPV" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/city/plating,
+/area/vtm/interior/millennium_tower/f4)
 "cPW" = (
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/city/plating_mono,
@@ -5695,6 +5723,22 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/police/fed)
+"dsN" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/clipboard{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/paper_bin{
+	pixel_y = 6;
+	pixel_x = -3
+	},
+/obj/item/pen/fourcolor,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "dtr" = (
 /obj/effect/decal/painting/second{
 	pixel_y = 32
@@ -6696,12 +6740,11 @@
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
 "eay" = (
-/obj/structure/chair/sofa/corp/right{
-	color = "#50C878";
-	dir = 8
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 10
 	},
-/obj/effect/landmark/start/darkpack/camarilla/hound,
-/turf/open/floor/city/plating,
+/obj/structure/table,
+/turf/open/floor/iron/showroomfloor,
 /area/vtm/interior/millennium_tower)
 "eaI" = (
 /obj/structure/chair/sofa/corp/right{
@@ -8526,7 +8569,11 @@
 /area/vtm/voivodate)
 "fcx" = (
 /obj/structure/ladder/manhole/down,
-/turf/open/floor/plating/asphalt,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/mop,
+/obj/machinery/light/directional/north,
+/turf/open/floor/city/toilet/large,
 /area/vtm/interior/millennium_tower)
 "fcU" = (
 /obj/effect/decal/wallpaper/paper/darkgreen,
@@ -8697,6 +8744,27 @@
 /obj/structure/stairs/west,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/gangbasement)
+"fiI" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 6
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "fiM" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/red/warning{
@@ -9331,6 +9399,7 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/tattoo)
 "fxi" = (
+/obj/effect/decal/rugs,
 /obj/machinery/light/directional/east,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
@@ -9440,6 +9509,10 @@
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/carpet/darkpack/greengold,
 /area/vtm/interior/apartment)
+"fzQ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "fzY" = (
 /obj/effect/decal/rugs{
 	pixel_y = -1
@@ -10193,9 +10266,6 @@
 "fXs" = (
 /obj/machinery/light/prince/directional/north,
 /obj/structure/table/wood/fancy/black,
-/obj/item/reagent_containers/blood/vitae{
-	pixel_x = -7
-	},
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f4)
 "fXL" = (
@@ -10621,6 +10691,13 @@
 	},
 /turf/open/floor/plating/stone,
 /area/vtm/interior/voivodate/sanctum)
+"gky" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/vampdoor/simple,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "gkQ" = (
 /obj/structure/closet/crate/bin,
 /obj/effect/turf_decal/siding/white/corner,
@@ -11647,9 +11724,12 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/church)
 "gOz" = (
-/obj/structure/chair/darkpack/green,
-/turf/open/floor/carpet/darkpack/greengold,
-/area/vtm/interior/endron_facility/restricted)
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "gOB" = (
 /obj/structure/vampfence/corner/rich{
 	dir = 1
@@ -12209,9 +12289,8 @@
 /turf/closed/wall/vampwall/junk,
 /area/vtm/interior/ghetto)
 "hdo" = (
-/obj/structure/closet/cardboard,
-/obj/effect/decal/rugs,
-/turf/open/floor/plating/asphalt,
+/obj/structure/reagent_dispensers/cleaningfluid,
+/turf/open/floor/city/toilet/large,
 /area/vtm/interior/millennium_tower)
 "hdr" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
@@ -15284,11 +15363,12 @@
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/sewer)
 "iUH" = (
-/obj/structure/table,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/suit/vampire/vest,
+/obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "iUK" = (
@@ -15696,9 +15776,8 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility)
 "jgM" = (
-/obj/structure/chair/darkpack/green,
-/turf/open/floor/city/plating,
-/area/vtm/interior/radio)
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "jgO" = (
 /obj/effect/landmark/start/darkpack/pentex/lead,
 /obj/machinery/button/curtain{
@@ -16160,7 +16239,6 @@
 /area/vtm/voivodate)
 "juv" = (
 /obj/structure/table,
-/obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/city/clinic,
 /area/vtm/interior/millennium_tower)
 "juw" = (
@@ -16771,8 +16849,10 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/clinic)
 "jOa" = (
-/obj/effect/decal/pallet,
-/turf/open/floor/plating/asphalt,
+/obj/structure/chair/darkpack/green{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/millennium_tower)
 "jOk" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -18044,6 +18124,10 @@
 /obj/item/clothing/head/vampire/helmet,
 /obj/item/clothing/head/vampire/helmet,
 /obj/item/clothing/head/vampire/helmet,
+/obj/item/clothing/suit/vampire/vest,
+/obj/item/clothing/suit/vampire/vest,
+/obj/item/clothing/suit/vampire/vest,
+/obj/item/clothing/suit/vampire/vest,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "kzb" = (
@@ -18760,6 +18844,10 @@
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/sewer)
+"kXH" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/city/plating,
+/area/vtm/interior/millennium_tower)
 "kXO" = (
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/rich/old,
@@ -19473,10 +19561,6 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/outside/park)
-"ltA" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/city/plating,
-/area/vtm/interior/millennium_tower/f4)
 "ltM" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/vampdoor/wood,
@@ -21300,6 +21384,13 @@
 /obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/wood/old,
 /area/vtm/interior/sewer)
+"myx" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "myN" = (
 /obj/structure/guncase,
 /obj/item/gun/ballistic/shotgun/vampire,
@@ -24190,9 +24281,6 @@
 /obj/underplate{
 	pixel_y = 8
 	},
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
 /turf/open/floor/city/clinic,
 /area/vtm/interior/millennium_tower)
 "ojb" = (
@@ -25025,6 +25113,20 @@
 /obj/effect/landmark/npcwall,
 /turf/open/misc/grass/random/bushes,
 /area/vtm/outside/park)
+"oDA" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/red/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/millennium_tower/f4)
 "oDM" = (
 /obj/structure/dresser{
 	pixel_y = 12
@@ -31696,14 +31798,6 @@
 	},
 /turf/open/water,
 /area/vtm/voivodate)
-"stS" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/red/full,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/f4)
 "suz" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -32228,6 +32322,11 @@
 	},
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/bianchiBank)
+"sFR" = (
+/obj/effect/decal/rugs,
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating/asphalt,
+/area/vtm/interior/millennium_tower)
 "sFV" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -32939,6 +33038,13 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/city/plating,
 /area/vtm/interior/radio)
+"sZs" = (
+/obj/effect/turf_decal/stripes/red/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/millennium_tower/f4)
 "sZw" = (
 /obj/effect/turf_decal/caution,
 /turf/open/floor/city/plating_mono,
@@ -33162,19 +33268,8 @@
 /area/vtm)
 "tgk" = (
 /obj/structure/closet/secure_closet/freezer,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
 /obj/item/storage/fancy/egg_box,
 /obj/item/reagent_containers/condiment/milk,
-/obj/item/reagent_containers/blood,
 /turf/open/floor/city/clinic,
 /area/vtm/interior/millennium_tower)
 "tgl" = (
@@ -34551,6 +34646,9 @@
 "tSz" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/red/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
 "tSB" = (
@@ -34880,6 +34978,15 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/supply)
+"uam" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/vampdoor/simple{
+	dir = 4
+	},
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "uar" = (
 /obj/effect/decal/cleanable/trash,
 /obj/effect/decal/cleanable/trash,
@@ -36322,6 +36429,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/radio)
+"uUn" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/vampdoor/simple,
+/turf/open/floor/city/toilet/large,
+/area/vtm/interior/millennium_tower)
 "uUq" = (
 /obj/structure/closet/crate/bin/undense,
 /turf/open/floor/plating/sidewalk,
@@ -37798,13 +37912,6 @@
 /obj/structure/table/countertop/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
-"vPk" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/city/plating_stone,
-/area/vtm/interior/millennium_tower/f4)
 "vPI" = (
 /obj/item/toy/crayon/spraycan,
 /obj/item/toy/crayon/spraycan,
@@ -38397,9 +38504,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/radio)
-"wjK" = (
-/turf/open/floor/city/plating_stone,
-/area/vtm/interior/millennium_tower/f4)
 "wkb" = (
 /obj/structure/table/countertop/bubway,
 /obj/machinery/chem_dispenser/drinks{
@@ -38513,7 +38617,6 @@
 /area/vtm/interior/gang)
 "wnA" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/carpet/darkpack/blacksilver,
 /area/vtm/interior/millennium_tower/f2)
 "wnB" = (
@@ -38563,6 +38666,13 @@
 	},
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/pizza)
+"wnN" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/chair/darkpack/red,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower)
 "wnP" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 1;
@@ -38912,11 +39022,10 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility/restricted)
 "wyy" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/structure/chair/sofa/corp/right{
 	color = "#50C878";
 	dir = 8
 	},
-/obj/effect/landmark/start/darkpack/camarilla/hound,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower)
 "wyO" = (
@@ -39062,6 +39171,11 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/chantry)
+"wCh" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "wCj" = (
 /obj/structure/flora/rock/darkpack,
 /turf/open/water/beach/vamp/deep,
@@ -39363,13 +39477,8 @@
 /turf/open/floor/city/bacotell,
 /area/vtm/interior/shop/bacotell)
 "wMp" = (
-/obj/structure/chair/sofa/corp{
-	color = "#50C878";
-	dir = 8
-	},
-/obj/effect/landmark/start/darkpack/camarilla/hound,
-/turf/open/floor/city/plating,
-/area/vtm/interior/millennium_tower)
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "wMr" = (
 /obj/structure/vampdoor/simple{
 	dir = 4
@@ -41117,10 +41226,6 @@
 /obj/structure/sink/directional/north,
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/police)
-"xNB" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/city/plating_stone,
-/area/vtm/interior/millennium_tower/f4)
 "xNG" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 4
@@ -41528,8 +41633,6 @@
 /area/vtm/voivodate)
 "xZv" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
 /turf/open/floor/carpet/darkpack/blackgold,
 /area/vtm/interior/millennium_tower/f4)
 "xZF" = (
@@ -58522,7 +58625,7 @@ puy
 puy
 luQ
 dIy
-bZr
+uSe
 uSe
 hbC
 sZn
@@ -58736,7 +58839,7 @@ puy
 puy
 luQ
 kdx
-jgM
+wwF
 qFb
 qFb
 qFb
@@ -59322,10 +59425,10 @@ sRJ
 fws
 myP
 vhR
-eay
-wMp
-wyy
 tMZ
+tMZ
+wyy
+bZr
 jWc
 bpf
 tMZ
@@ -59428,8 +59531,8 @@ exk
 sRJ
 kiG
 kiG
-cFJ
-cFJ
+vhR
+tMZ
 cFJ
 cFJ
 cFJ
@@ -59535,19 +59638,19 @@ nod
 sRJ
 sRJ
 sRJ
+vhR
+kXH
 cju
-mnN
-hdo
 fcx
 hdo
+cFJ
 xoa
-xoa
-xoa
+oul
 xoa
 oul
 xoa
 xoa
-xoa
+mnN
 cFJ
 iqO
 wdp
@@ -59642,12 +59745,12 @@ sRJ
 sRJ
 juv
 nkC
-cju
-bUB
-xoa
-xoa
-xoa
-xoa
+vhR
+tMZ
+uUn
+bGG
+bGG
+cFJ
 nIU
 xoa
 xoa
@@ -59749,12 +59852,12 @@ haC
 cvz
 cFJ
 cFJ
-cju
-plT
-xoa
-xoa
-xoa
-xoa
+vhR
+uam
+cFJ
+cFJ
+cFJ
+cFJ
 xoa
 xoa
 xoa
@@ -59857,12 +59960,12 @@ qwE
 qwE
 shE
 cju
-xoa
-xoa
-xoa
-xoa
-xoa
-xoa
+jgM
+jOa
+cic
+jOa
+cFJ
+plT
 xoa
 xoa
 xoa
@@ -59964,11 +60067,11 @@ epb
 epb
 epb
 cju
-xoa
-xoa
-xoa
-xoa
-xoa
+jgM
+jgM
+jgM
+jgM
+cFJ
 xoa
 xoa
 xoa
@@ -60071,18 +60174,18 @@ bbV
 bbV
 bZj
 cju
-xoa
-xoa
-xoa
-xoa
-jOa
+dsN
+acj
+wnN
+eay
+cFJ
 nLS
 xoa
 xoa
 xoa
 nLS
 xoa
-xoa
+sFR
 eIv
 iqO
 wdp
@@ -60178,18 +60281,18 @@ maG
 sxo
 fCU
 cju
-sTl
-sTl
-sTl
-fxi
-jOa
-xoa
-xoa
+aac
+cdC
+gOz
+fiI
+cFJ
 xoa
 fxi
+sTl
+fxi
 xoa
 xoa
-xoa
+sFR
 cFJ
 iqO
 qyx
@@ -60286,13 +60389,13 @@ cFJ
 cFJ
 cFJ
 cFJ
+cFJ
+cFJ
+cFJ
+cFJ
+cFJ
+cFJ
 vOC
-cFJ
-cFJ
-cFJ
-cFJ
-cFJ
-cFJ
 cFJ
 cFJ
 cFJ
@@ -77721,7 +77824,7 @@ eeP
 eeP
 eeP
 vZM
-gOz
+lxK
 pid
 lxK
 lxK
@@ -81482,10 +81585,10 @@ nls
 nls
 nls
 bTa
-aIU
-xNB
+wCh
+fzQ
 bTa
-vPk
+myx
 bTa
 rdj
 rdj
@@ -81588,11 +81691,11 @@ nls
 nls
 nls
 nls
-cdC
-wjK
-wjK
-cdC
-wjK
+gky
+wMp
+wMp
+bUB
+wMp
 bTa
 rdj
 rdj
@@ -81908,7 +82011,7 @@ uXm
 wYE
 iiO
 gQu
-stS
+oDA
 bTa
 uZF
 mrm
@@ -82015,7 +82118,7 @@ uXm
 wYE
 jVD
 jVD
-bGG
+sZs
 jJY
 mrm
 mrm
@@ -82126,7 +82229,7 @@ tSz
 bTa
 kyL
 iUH
-ltA
+cPV
 sPw
 bTa
 rdj

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -2776,10 +2776,7 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/coffee)
 "bGG" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/item/ammo_box/darkpack/c50,
-/obj/item/ammo_box/darkpack/c50,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "bGP" = (
@@ -3546,12 +3543,12 @@
 /turf/open/floor/iron/stairs,
 /area/vtm/interior/supply)
 "cdC" = (
-/obj/item/clothing/suit/vampire/eod,
-/obj/item/clothing/head/vampire/eod,
-/obj/structure/closet/bombcloset{
-	anchored = 1
+/obj/effect/turf_decal/siding/white{
+	dir = 8
 	},
-/turf/open/floor/city/plating,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/red/full,
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
 "cdL" = (
 /obj/structure/table,
@@ -5316,10 +5313,13 @@
 /turf/open/floor/carpet/black,
 /area/vtm/interior/laundromat)
 "ddx" = (
-/obj/item/gun/ballistic/automatic/darkpack/ar15,
-/obj/structure/guncase,
-/obj/item/gun/ballistic/automatic/darkpack/ar15,
-/obj/item/gun/ballistic/automatic/darkpack/sniper,
+/obj/item/clothing/suit/vampire/eod,
+/obj/item/clothing/head/vampire/eod,
+/obj/structure/closet/bombcloset{
+	anchored = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "ddB" = (
@@ -15284,11 +15284,10 @@
 /area/vtm/interior/sewer)
 "iUH" = (
 /obj/structure/table,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
+/obj/item/clothing/suit/vampire/vest,
+/obj/item/clothing/suit/vampire/vest,
+/obj/item/clothing/suit/vampire/vest,
+/obj/item/clothing/suit/vampire/vest,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "iUK" = (
@@ -16627,9 +16626,9 @@
 /turf/open/water/river,
 /area/vtm/interior/voivodate/cave)
 "jJY" = (
-/obj/machinery/door/poddoor/shutters/armory{
-	name = "Armory Shutters"
-	},
+/obj/structure/vampdoor/reinf,
+/obj/effect/mapping_helpers/door/access/prince,
+/obj/effect/mapping_helpers/door/lock,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "jKc" = (
@@ -18038,11 +18037,12 @@
 /turf/open/floor/wood/ornate,
 /area/vtm/interior/voivodate)
 "kyL" = (
-/obj/machinery/button/door{
-	id = 10
-	},
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/item/clothing/head/vampire/helmet,
+/obj/item/clothing/head/vampire/helmet,
+/obj/item/clothing/head/vampire/helmet,
+/obj/item/clothing/head/vampire/helmet,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "kzb" = (
@@ -23644,11 +23644,11 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/anarch/basement)
 "nTM" = (
-/obj/structure/table,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/head/vampire/helmet,
-/obj/item/clothing/head/vampire/helmet,
-/obj/item/clothing/suit/vampire/vest,
+/obj/item/gun/ballistic/automatic/darkpack/ar15,
+/obj/structure/guncase,
+/obj/item/gun/ballistic/automatic/darkpack/ar15,
+/obj/item/gun/ballistic/automatic/darkpack/sniper,
+/obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "nUd" = (
@@ -32574,11 +32574,19 @@
 /area/vtm/interior/voivodate/sanctum)
 "sPw" = (
 /obj/machinery/light/directional/east,
-/obj/item/knife/vamp,
-/obj/item/knife/vamp,
 /obj/structure/table,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
+/obj/item/melee/baton/vamp{
+	pixel_y = 10
+	},
+/obj/item/melee/baton/vamp{
+	pixel_y = 10
+	},
+/obj/item/melee/baton/vamp{
+	pixel_y = 10
+	},
+/obj/item/melee/baton/vamp{
+	pixel_y = 10
+	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "sPI" = (
@@ -33330,6 +33338,11 @@
 /obj/item/ammo_box/magazine/darkpack45acp,
 /obj/item/ammo_box/darkpack/c45acp,
 /obj/structure/table,
+/obj/item/gun/ballistic/automatic/pistol/darkpack/m1911,
+/obj/item/gun/ballistic/automatic/pistol/darkpack/m1911,
+/obj/item/ammo_box/magazine/darkpack45acp,
+/obj/item/ammo_box/magazine/darkpack45acp,
+/obj/item/ammo_box/darkpack/c45acp,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "tmn" = (
@@ -34523,11 +34536,8 @@
 /turf/open/floor/city/plating,
 /area/vtm/interior/tattoo)
 "tSz" = (
-/obj/structure/table/reinforced,
-/obj/keypad/armory,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
-	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
 "tSB" = (
@@ -35305,6 +35315,10 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/junk,
 /area/vtm/interior/strip)
+"uro" = (
+/obj/effect/turf_decal/stripes/red/full,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/millennium_tower/f4)
 "urv" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcwall,
@@ -36489,12 +36503,8 @@
 /area/vtm/voivodate)
 "uZF" = (
 /obj/structure/table,
-/obj/item/ammo_box/darkpack/c556,
-/obj/item/ammo_box/darkpack/c556,
-/obj/item/ammo_box/darkpack/c556,
-/obj/item/ammo_box/darkpack/c556,
-/obj/item/ammo_box/magazine/darkpack556,
-/obj/item/ammo_box/magazine/darkpack556,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "uZZ" = (
@@ -36834,11 +36844,14 @@
 /area/vtm/outside/financialdistrict)
 "vkd" = (
 /obj/structure/table,
-/obj/item/ammo_box/darkpack/c45acp,
-/obj/item/ammo_box/magazine/darkpack45acp,
-/obj/item/ammo_box/magazine/darkpack45acp,
-/obj/item/gun/ballistic/automatic/pistol/darkpack/m1911,
-/obj/item/gun/ballistic/automatic/pistol/darkpack/m1911,
+/obj/item/ammo_box/darkpack/c50,
+/obj/item/ammo_box/darkpack/c50,
+/obj/item/ammo_box/darkpack/c556,
+/obj/item/ammo_box/darkpack/c556,
+/obj/item/ammo_box/darkpack/c556,
+/obj/item/ammo_box/darkpack/c556,
+/obj/item/ammo_box/magazine/darkpack556,
+/obj/item/ammo_box/magazine/darkpack556,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "vkQ" = (
@@ -81552,10 +81565,10 @@ nls
 nls
 nls
 bTa
-bTa
-bTa
-bTa
-bTa
+mrm
+mrm
+mrm
+mrm
 bTa
 rdj
 rdj
@@ -81659,10 +81672,10 @@ nls
 nls
 nls
 bTa
-bGG
-mrm
-hNG
-cdC
+bTa
+bTa
+bTa
+bTa
 bTa
 rdj
 rdj
@@ -81768,7 +81781,7 @@ qsR
 bTa
 ddx
 mrm
-mrm
+hNG
 nTM
 bTa
 rdj
@@ -81871,7 +81884,7 @@ uXm
 wYE
 iiO
 gQu
-gQu
+cdC
 bTa
 uZF
 mrm
@@ -81978,7 +81991,7 @@ uXm
 wYE
 jVD
 jVD
-jVD
+uro
 jJY
 mrm
 mrm
@@ -82089,7 +82102,7 @@ tSz
 bTa
 kyL
 iUH
-mrm
+bGG
 sPw
 bTa
 rdj

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -1061,6 +1061,11 @@
 	},
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
+"aIU" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror/directional/north,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "aIX" = (
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/city,
@@ -2776,8 +2781,8 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/coffee)
 "bGG" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/city/plating,
+/obj/effect/turf_decal/stripes/red/full,
+/turf/open/floor/city/plating_mono,
 /area/vtm/interior/millennium_tower/f4)
 "bGP" = (
 /obj/structure/table/wood/fancy/green,
@@ -3543,12 +3548,8 @@
 /turf/open/floor/iron/stairs,
 /area/vtm/interior/supply)
 "cdC" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/red/full,
-/turf/open/floor/city/plating_mono,
+/obj/structure/vampdoor/simple,
+/turf/open/floor/city/plating_stone,
 /area/vtm/interior/millennium_tower/f4)
 "cdL" = (
 /obj/structure/table,
@@ -18490,7 +18491,7 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/coffee)
 "kOe" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "kOq" = (
@@ -19472,6 +19473,10 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/outside/park)
+"ltA" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/city/plating,
+/area/vtm/interior/millennium_tower/f4)
 "ltM" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/vampdoor/wood,
@@ -31691,6 +31696,14 @@
 	},
 /turf/open/water,
 /area/vtm/voivodate)
+"stS" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/red/full,
+/turf/open/floor/city/plating_mono,
+/area/vtm/interior/millennium_tower/f4)
 "suz" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -34395,7 +34408,7 @@
 /area/vtm/interior/clinic)
 "tOI" = (
 /obj/fusebox,
-/obj/structure/tank_holder/extinguisher,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "tOX" = (
@@ -35315,10 +35328,6 @@
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/junk,
 /area/vtm/interior/strip)
-"uro" = (
-/obj/effect/turf_decal/stripes/red/full,
-/turf/open/floor/city/plating_mono,
-/area/vtm/interior/millennium_tower/f4)
 "urv" = (
 /obj/effect/turf_decal/bordur,
 /obj/effect/landmark/npcwall,
@@ -36939,6 +36948,7 @@
 /area/vtm/interior/endron_facility/restricted)
 "vnx" = (
 /obj/machinery/light/directional/north,
+/obj/machinery/washing_machine,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior/millennium_tower/f4)
 "vnA" = (
@@ -37788,6 +37798,13 @@
 /obj/structure/table/countertop/red,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
+"vPk" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "vPI" = (
 /obj/item/toy/crayon/spraycan,
 /obj/item/toy/crayon/spraycan,
@@ -38380,6 +38397,9 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/radio)
+"wjK" = (
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "wkb" = (
 /obj/structure/table/countertop/bubway,
 /obj/machinery/chem_dispenser/drinks{
@@ -41097,6 +41117,10 @@
 /obj/structure/sink/directional/north,
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/police)
+"xNB" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/city/plating_stone,
+/area/vtm/interior/millennium_tower/f4)
 "xNG" = (
 /obj/effect/turf_decal/bordur/corner{
 	dir = 4
@@ -81458,10 +81482,10 @@ nls
 nls
 nls
 bTa
-mrm
-mrm
-mrm
-mrm
+aIU
+xNB
+bTa
+vPk
 bTa
 rdj
 rdj
@@ -81564,11 +81588,11 @@ nls
 nls
 nls
 nls
-bTa
-mrm
-mrm
-mrm
-mrm
+cdC
+wjK
+wjK
+cdC
+wjK
 bTa
 rdj
 rdj
@@ -81884,7 +81908,7 @@ uXm
 wYE
 iiO
 gQu
-cdC
+stS
 bTa
 uZF
 mrm
@@ -81991,7 +82015,7 @@ uXm
 wYE
 jVD
 jVD
-uro
+bGG
 jJY
 mrm
 mrm
@@ -82102,7 +82126,7 @@ tSz
 bTa
 kyL
 iUH
-bGG
+ltA
 sPw
 bTa
 rdj

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -15253,10 +15253,6 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/unionsquare)
-"iQA" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/darkpack/cyan,
-/area/vtm/interior/millennium_tower)
 "iQB" = (
 /obj/structure/vampdoor/glass{
 	dir = 4
@@ -19260,6 +19256,27 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/unionsquare)
+"llu" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower/f4)
 "llw" = (
 /obj/effect/spawner/random/bedsheet/any,
 /obj/structure/bed,
@@ -23606,10 +23623,9 @@
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/chantry)
 "nQd" = (
-/obj/keypad/panic_room,
-/obj/effect/decal/wallpaper/stone,
-/turf/closed/wall/vampwall/rich,
-/area/vtm/interior/millennium_tower/f4)
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "nQk" = (
 /obj/structure/vampfence/corner/rich,
 /obj/effect/turf_decal/bordur{
@@ -25170,12 +25186,6 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/voivodate)
-"oEJ" = (
-/obj/structure/table,
-/obj/item/mop,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/city/toilet/large,
-/area/vtm/interior/millennium_tower)
 "oEV" = (
 /obj/structure/closet/crate/bin/undense{
 	pixel_x = -7;
@@ -32067,25 +32077,6 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/anarch/basement)
-"syF" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/freezer/commercial/small,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/turf/open/floor/iron/showroomfloor,
-/area/vtm/interior/millennium_tower/f4)
 "syQ" = (
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -36332,6 +36323,12 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/outside/financialdistrict)
+"uPR" = (
+/obj/structure/table,
+/obj/item/mop,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/city/toilet/large,
+/area/vtm/interior/millennium_tower)
 "uQj" = (
 /obj/structure/table/wood,
 /obj/structure/closet/mini_fridge{
@@ -39894,6 +39891,25 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior)
+"wYc" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower/f4)
 "wYh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -40927,27 +40943,6 @@
 	},
 /turf/open/floor/stone,
 /area/vtm/interior/mallunderground)
-"xHv" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer/commercial/small,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/turf/open/floor/iron/showroomfloor,
-/area/vtm/interior/millennium_tower/f4)
 "xHz" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/vampwall/metal/reinforced,
@@ -59786,7 +59781,7 @@ vhR
 tMZ
 uUn
 bGG
-oEJ
+uPR
 cFJ
 nIU
 xoa
@@ -60104,7 +60099,7 @@ epb
 epb
 epb
 jWc
-iQA
+nQd
 jgM
 jgM
 jgM
@@ -82039,7 +82034,7 @@ jVD
 bTa
 bTa
 gTy
-nQd
+uwK
 jGT
 jGT
 uwK
@@ -82470,7 +82465,7 @@ mrm
 vgt
 gpq
 lIb
-xHv
+llu
 jne
 lRJ
 tSe
@@ -82577,7 +82572,7 @@ pcz
 mrm
 mrm
 mrm
-syF
+wYc
 xte
 tSe
 tSe

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -18135,14 +18135,10 @@
 "kyL" = (
 /obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/item/clothing/head/vampire/helmet,
-/obj/item/clothing/head/vampire/helmet,
-/obj/item/clothing/head/vampire/helmet,
-/obj/item/clothing/head/vampire/helmet,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/suit/vampire/vest,
-/obj/item/clothing/suit/vampire/vest,
+/obj/item/vampire_stake,
+/obj/item/vampire_stake,
+/obj/item/vampire_stake,
+/obj/item/vampire_stake,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "kzb" = (
@@ -21398,6 +21394,10 @@
 	},
 /turf/open/floor/wood/smooth/old,
 /area/vtm/interior/apartment)
+"mxQ" = (
+/obj/structure/chair/darkpack/green,
+/turf/open/floor/carpet/darkpack/greengold,
+/area/vtm/interior/endron_facility/restricted)
 "myg" = (
 /obj/effect/turf_decal/bordur/inverse{
 	dir = 4
@@ -77885,7 +77885,7 @@ eeP
 eeP
 eeP
 vZM
-lxK
+mxQ
 pid
 lxK
 lxK

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -1225,12 +1225,12 @@
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/radio)
 "aMY" = (
-/obj/effect/mapping_helpers/door/access/camarilla,
 /obj/effect/mapping_helpers/door/lock,
 /obj/structure/lattice/pentex,
 /obj/structure/vampdoor/reinf{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/door/access/prince,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "aNJ" = (
@@ -3056,6 +3056,10 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/chantry)
+"bOi" = (
+/obj/effect/decal/cleanable/trash,
+/turf/open/floor/plating/canal,
+/area/vtm/interior/sewer)
 "bOn" = (
 /obj/effect/decal/pallet,
 /obj/structure/bonfire/prelit/fire_barrel,
@@ -6787,7 +6791,7 @@
 /obj/structure/lattice/pentex,
 /obj/structure/vampdoor/reinf,
 /obj/effect/mapping_helpers/door/lock,
-/obj/effect/mapping_helpers/door/access/camarilla,
+/obj/effect/mapping_helpers/door/access/prince,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "ecA" = (
@@ -25232,6 +25236,11 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
+"oHt" = (
+/obj/structure/ladder/manhole/up,
+/obj/effect/decal/cleanable/trash,
+/turf/open/floor/plating/canal,
+/area/vtm/interior/sewer)
 "oHx" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/darkpack/old,
@@ -29904,6 +29913,13 @@
 /obj/item/reagent_containers/cup/bottle/fluorine,
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/clinic)
+"rkX" = (
+/obj/structure/chair/sofa/corp{
+	color = "#50C878";
+	dir = 8
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/millennium_tower)
 "rlb" = (
 /obj/structure/curtain/bounty{
 	open = 0
@@ -36327,6 +36343,7 @@
 /obj/structure/table,
 /obj/item/mop,
 /obj/item/reagent_containers/cup/bucket,
+/obj/item/storage/bag/trash,
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/millennium_tower)
 "uQj" = (
@@ -48330,7 +48347,7 @@ arg
 arg
 arg
 tiW
-hxj
+bOi
 ofT
 hxj
 kzb
@@ -48437,7 +48454,7 @@ arg
 mvR
 aRA
 tiW
-oNK
+oHt
 ofT
 hxj
 kzb
@@ -59458,8 +59475,8 @@ fws
 myP
 vhR
 tMZ
-tMZ
 wyy
+rkX
 bZr
 jWc
 bpf

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -1225,12 +1225,12 @@
 /turf/open/floor/carpet/darkpack/bluesilver,
 /area/vtm/interior/radio)
 "aMY" = (
-/obj/structure/vampdoor/simple{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/door/access/camarilla,
 /obj/effect/mapping_helpers/door/lock,
 /obj/structure/lattice/pentex,
+/obj/structure/vampdoor/reinf{
+	dir = 4
+	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "aNJ" = (
@@ -2901,6 +2901,25 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/voivodate)
+"bIy" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower/f4)
 "bJc" = (
 /obj/structure/hedge{
 	pixel_x = 0;
@@ -6785,13 +6804,9 @@
 /area/vtm/interior/endron_facility/restricted)
 "ech" = (
 /obj/structure/lattice/pentex,
-/obj/machinery/door/poddoor/shutters/armory{
-	damage_deflection = 60;
-	max_integrity = 300;
-	name = "Panic Room Shutters";
-	id = 12;
-	dir = 1
-	},
+/obj/structure/vampdoor/reinf,
+/obj/effect/mapping_helpers/door/lock,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/city/plating,
 /area/vtm/interior/millennium_tower/f4)
 "ecA" = (
@@ -9042,6 +9057,12 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
+"foI" = (
+/obj/structure/table,
+/obj/item/mop,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/city/toilet/large,
+/area/vtm/interior/millennium_tower)
 "foW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -9953,6 +9974,27 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility)
+"fNe" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower/f4)
 "fNI" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -14312,7 +14354,6 @@
 /obj/structure/table/greyscale{
 	name = "metal table"
 	},
-/obj/keypad/panic_room,
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
 	},
@@ -23435,9 +23476,6 @@
 "nKu" = (
 /obj/structure/table,
 /obj/item/smartphone/clean,
-/obj/item/reagent_containers/blood/vitae{
-	pixel_x = -7
-	},
 /obj/item/flashlight{
 	pixel_x = 9;
 	pixel_y = 5
@@ -24323,10 +24361,6 @@
 "okq" = (
 /obj/structure/table/greyscale{
 	name = "metal table"
-	},
-/obj/item/documents/syndicate/blue{
-	desc = "A bundle of papers detailing the features of your new Safe Haven Construction panic room. There is fine print at the bottom stating usage of the panic room automatically indemnifies the company of any and all liability or wrongdoing, or death and disfigurement.";
-	name = "Safe Haven Panic Room"
 	},
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -26164,10 +26198,6 @@
 	},
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/gangbasement)
-"plz" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/darkpack/cyan,
-/area/vtm/interior/millennium_tower)
 "plI" = (
 /obj/item/clothing/suit/vampire/trench/voivode{
 	pixel_x = 1;
@@ -26518,12 +26548,6 @@
 /obj/structure/table/optable,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/voivodate/sanctum)
-"puR" = (
-/obj/structure/table,
-/obj/item/mop,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/city/toilet/large,
-/area/vtm/interior/millennium_tower)
 "puS" = (
 /obj/structure/hoop,
 /turf/open/floor/plating/sidewalk/poor,
@@ -40759,6 +40783,10 @@
 	},
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/clinic)
+"xBq" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "xBs" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -59758,7 +59786,7 @@ vhR
 tMZ
 uUn
 bGG
-puR
+foI
 cFJ
 nIU
 xoa
@@ -60076,7 +60104,7 @@ epb
 epb
 epb
 cju
-plz
+xBq
 jgM
 jgM
 jgM
@@ -82442,7 +82470,7 @@ mrm
 vgt
 gpq
 lIb
-mrm
+fNe
 jne
 lRJ
 tSe
@@ -82549,7 +82577,7 @@ pcz
 mrm
 mrm
 mrm
-mrm
+bIy
 xte
 tSe
 tSe

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -2901,25 +2901,6 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/voivodate)
-"bIy" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner,
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/freezer/commercial/small,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/obj/item/reagent_containers/blood/vitae,
-/turf/open/floor/iron/showroomfloor,
-/area/vtm/interior/millennium_tower/f4)
 "bJc" = (
 /obj/structure/hedge{
 	pixel_x = 0;
@@ -9057,12 +9038,6 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/wood/smooth,
 /area/vtm/interior)
-"foI" = (
-/obj/structure/table,
-/obj/item/mop,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/city/toilet/large,
-/area/vtm/interior/millennium_tower)
 "foW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -9974,27 +9949,6 @@
 	},
 /turf/open/floor/city/plating,
 /area/vtm/interior/endron_facility)
-"fNe" = (
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/thinplating/dark,
-/obj/effect/turf_decal/siding/thinplating/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/freezer/commercial/small,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/turf/open/floor/iron/showroomfloor,
-/area/vtm/interior/millennium_tower/f4)
 "fNI" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -15299,6 +15253,10 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/outside/unionsquare)
+"iQA" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "iQB" = (
 /obj/structure/vampdoor/glass{
 	dir = 4
@@ -25212,6 +25170,12 @@
 	},
 /turf/open/misc/dirt,
 /area/vtm/voivodate)
+"oEJ" = (
+/obj/structure/table,
+/obj/item/mop,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/city/toilet/large,
+/area/vtm/interior/millennium_tower)
 "oEV" = (
 /obj/structure/closet/crate/bin/undense{
 	pixel_x = -7;
@@ -32103,6 +32067,25 @@
 /obj/effect/decal/cleanable/trash,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/anarch/basement)
+"syF" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/obj/item/reagent_containers/blood/vitae,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower/f4)
 "syQ" = (
 /obj/machinery/light/prince/directional/north,
 /turf/open/floor/wood/smooth/old,
@@ -40783,10 +40766,6 @@
 	},
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/clinic)
-"xBq" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/darkpack/cyan,
-/area/vtm/interior/millennium_tower)
 "xBs" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -40948,6 +40927,27 @@
 	},
 /turf/open/floor/stone,
 /area/vtm/interior/mallunderground)
+"xHv" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/obj/item/reagent_containers/blood,
+/turf/open/floor/iron/showroomfloor,
+/area/vtm/interior/millennium_tower/f4)
 "xHz" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/vampwall/metal/reinforced,
@@ -59786,7 +59786,7 @@ vhR
 tMZ
 uUn
 bGG
-foI
+oEJ
 cFJ
 nIU
 xoa
@@ -59889,7 +59889,7 @@ haC
 cvz
 cFJ
 cFJ
-vhR
+jWc
 uam
 cFJ
 cFJ
@@ -59996,7 +59996,7 @@ sTd
 qwE
 qwE
 shE
-cju
+jWc
 jgM
 jOa
 cic
@@ -60103,8 +60103,8 @@ epb
 epb
 epb
 epb
-cju
-xBq
+jWc
+iQA
 jgM
 jgM
 jgM
@@ -60210,7 +60210,7 @@ xNM
 bbV
 bbV
 bZj
-cju
+jWc
 dsN
 acj
 wnN
@@ -60317,7 +60317,7 @@ rCG
 maG
 sxo
 fCU
-cju
+jWc
 aac
 cdC
 gOz
@@ -82470,7 +82470,7 @@ mrm
 vgt
 gpq
 lIb
-fNe
+xHv
 jne
 lRJ
 tSe
@@ -82577,7 +82577,7 @@ pcz
 mrm
 mrm
 mrm
-bIy
+syF
 xte
 tSe
 tSe

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -3056,10 +3056,6 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/chantry)
-"bOi" = (
-/obj/effect/decal/cleanable/trash,
-/turf/open/floor/plating/canal,
-/area/vtm/interior/sewer)
 "bOn" = (
 /obj/effect/decal/pallet,
 /obj/structure/bonfire/prelit/fire_barrel,
@@ -3245,6 +3241,7 @@
 /area/vtm/interior/voivodate)
 "bUB" = (
 /obj/structure/vampdoor/simple,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/millennium_tower/f4)
 "bUK" = (
@@ -4907,7 +4904,18 @@
 /area/vtm/interior/laundromat)
 "cPV" = (
 /obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/city/plating,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/effect/turf_decal/siding/thinplating/dark/corner,
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/vtm/interior/millennium_tower/f4)
 "cPW" = (
 /obj/effect/decal/cleanable/trash,
@@ -8746,21 +8754,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 6
 	},
-/obj/structure/closet/secure_closet/freezer/commercial/small,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/showroomfloor,
 /area/vtm/interior/millennium_tower)
 "fiM" = (
@@ -10694,6 +10688,7 @@
 	dir = 1
 	},
 /obj/structure/vampdoor/simple,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/city/plating_stone,
 /area/vtm/interior/millennium_tower/f4)
 "gkQ" = (
@@ -15361,13 +15356,28 @@
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/sewer)
 "iUH" = (
-/obj/structure/closet/secure_closet/freezer/fridge/all_access,
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
 /obj/item/reagent_containers/blood/vitae,
-/turf/open/floor/city/plating,
+/obj/structure/closet/secure_closet/freezer/commercial/small,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/vtm/interior/millennium_tower/f4)
 "iUK" = (
 /obj/machinery/light/directional/east,
@@ -16617,6 +16627,13 @@
 /obj/structure/platform/lowwall/old/window,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/chantry)
+"jHj" = (
+/obj/structure/chair/sofa/corp{
+	color = "#50C878";
+	dir = 8
+	},
+/turf/open/floor/city/plating,
+/area/vtm/interior/millennium_tower)
 "jHA" = (
 /obj/structure/vampipe{
 	icon_state = "piping35"
@@ -19274,11 +19291,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark/corner{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/freezer/commercial/small,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
-/obj/item/reagent_containers/blood,
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/showroomfloor,
 /area/vtm/interior/millennium_tower/f4)
 "llw" = (
@@ -25236,11 +25249,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/city/plating_mono,
 /area/vtm/interior/clinic)
-"oHt" = (
-/obj/structure/ladder/manhole/up,
-/obj/effect/decal/cleanable/trash,
-/turf/open/floor/plating/canal,
-/area/vtm/interior/sewer)
 "oHx" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/darkpack/old,
@@ -29913,13 +29921,6 @@
 /obj/item/reagent_containers/cup/bottle/fluorine,
 /turf/open/floor/city/circled/large,
 /area/vtm/interior/clinic)
-"rkX" = (
-/obj/structure/chair/sofa/corp{
-	color = "#50C878";
-	dir = 8
-	},
-/turf/open/floor/city/plating,
-/area/vtm/interior/millennium_tower)
 "rlb" = (
 /obj/structure/curtain/bounty{
 	open = 0
@@ -30764,6 +30765,11 @@
 /obj/structure/flora/tree/vamp,
 /turf/open/misc/grass,
 /area/vtm/voivodate)
+"rJh" = (
+/obj/structure/ladder/manhole/up,
+/obj/effect/decal/cleanable/trash,
+/turf/open/floor/plating/canal,
+/area/vtm/interior/sewer)
 "rJm" = (
 /obj/machinery/atm{
 	pixel_y = 25
@@ -35008,6 +35014,7 @@
 /obj/structure/vampdoor/simple{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/millennium_tower)
 "uar" = (
@@ -36464,6 +36471,7 @@
 	dir = 1
 	},
 /obj/structure/vampdoor/simple,
+/obj/effect/mapping_helpers/door/access/camarilla,
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/millennium_tower)
 "uUq" = (
@@ -39832,6 +39840,10 @@
 /obj/effect/mapping_helpers/door/access/voivodate,
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/voivodate)
+"wUP" = (
+/obj/effect/decal/cleanable/trash,
+/turf/open/floor/plating/canal,
+/area/vtm/interior/sewer)
 "wUS" = (
 /obj/structure/chair/stool/bar/darkpack/red,
 /turf/open/floor/city/bacotell,
@@ -48347,7 +48359,7 @@ arg
 arg
 arg
 tiW
-bOi
+wUP
 ofT
 hxj
 kzb
@@ -48454,7 +48466,7 @@ arg
 mvR
 aRA
 tiW
-oHt
+rJh
 ofT
 hxj
 kzb
@@ -59476,7 +59488,7 @@ myP
 vhR
 tMZ
 wyy
-rkX
+jHj
 bZr
 jWc
 bpf

--- a/_maps/map_files/Vampire/special_fran/special_francisco.dmm
+++ b/_maps/map_files/Vampire/special_fran/special_francisco.dmm
@@ -3732,6 +3732,7 @@
 /obj/item/newspaper{
 	pixel_y = 6
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/carpet/darkpack/cyan,
 /area/vtm/interior/millennium_tower)
 "cie" = (
@@ -8568,11 +8569,8 @@
 /turf/open/misc/dirt,
 /area/vtm/voivodate)
 "fcx" = (
-/obj/structure/ladder/manhole/down,
-/obj/structure/table,
-/obj/item/reagent_containers/cup/bucket,
-/obj/item/mop,
 /obj/machinery/light/directional/north,
+/obj/structure/ladder/manhole/down,
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/millennium_tower)
 "fcU" = (
@@ -11728,6 +11726,7 @@
 	dir = 4
 	},
 /obj/machinery/iv_drip,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/vtm/interior/millennium_tower)
 "gOB" = (
@@ -26165,6 +26164,10 @@
 	},
 /turf/open/floor/city/toilet/large,
 /area/vtm/interior/gangbasement)
+"plz" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/darkpack/cyan,
+/area/vtm/interior/millennium_tower)
 "plI" = (
 /obj/item/clothing/suit/vampire/trench/voivode{
 	pixel_x = 1;
@@ -26515,6 +26518,12 @@
 /obj/structure/table/optable,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/voivodate/sanctum)
+"puR" = (
+/obj/structure/table,
+/obj/item/mop,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/city/toilet/large,
+/area/vtm/interior/millennium_tower)
 "puS" = (
 /obj/structure/hoop,
 /turf/open/floor/plating/sidewalk/poor,
@@ -59749,7 +59758,7 @@ vhR
 tMZ
 uUn
 bGG
-bGG
+puR
 cFJ
 nIU
 xoa
@@ -60067,7 +60076,7 @@ epb
 epb
 epb
 cju
-jgM
+plz
 jgM
 jgM
 jgM


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Touching up the Camarilla Tower in the short term. Adds:

- Bathroom to allow clothes washing, ass wiping, etc
- making the armory accessible by making it a normal door, removing its unique status and circumventing the bug locking it entirely. 
- hiding round start vampire blood away from tower employee access, by making it a flavorful care room for the Hemophiliac Chairman
- changes the sewer escape to a supply closet instead of the garage
- Panic room changed to be accessible and adds some blood storage ( +3 vampire vitae bags)

Armory Stock Changes:
-  -2 Knives
- +4 Police Batons
- +4 Stakes
- -2 Police Helmets
- -2 Bulletproof Vest

## Why It's Good For The Game

The armory should be accessible, same with the panic room, and the armory probably shouldn't have fighting knives inside of them. Adding bathrooms and cleaning closets helps for all sorts of things, and uses existing space. Hiding vampire blood removes a tired round start tedium where players have to pretend to engage with the idea that there is a few bags of blood out, every start of the evening. Now it is in a room that makes sense, but is still very weird for a normal office building to have. 


## Testing Photographs and Procedure

<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 OR 2 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details open>
<summary>Screenshots & Videos</summary>

<img width="766" height="942" alt="StrongDMM_iDgUdzUJJG" src="https://github.com/user-attachments/assets/5e51f545-e693-48fe-9954-515150b2ce50" />
<img width="692" height="646" alt="StrongDMM_DDTBPUUrbE" src="https://github.com/user-attachments/assets/634cf232-5235-4369-b0ed-5b0494c5c503" />
<img width="1137" height="1045" alt="StrongDMM_cEeJsqKQ1G" src="https://github.com/user-attachments/assets/f43d2d1b-2134-445e-bc26-4b391e1964e6" />
<img width="1734" height="1369" alt="dreamseeker_yY20ibWfnv" src="https://github.com/user-attachments/assets/883de6d5-94e1-4d9d-af94-93d66647027e" />
<img width="1734" height="1369" alt="dreamseeker_RKibEwaQ4a" src="https://github.com/user-attachments/assets/27643ae9-8058-4514-8fdd-80d3300d0ac3" />
<img width="1734" height="1369" alt="dreamseeker_RWDi3GQK8z" src="https://github.com/user-attachments/assets/3239bb7e-e54e-4a17-9d51-d914e299a000" />
<img width="1734" height="1369" alt="dreamseeker_Br0Bcg7f1U" src="https://github.com/user-attachments/assets/50f8490a-dfdf-45e3-a808-7bbeac51b96a" />
<img width="1734" height="1369" alt="dreamseeker_HIQ1C1Ruau" src="https://github.com/user-attachments/assets/474f497c-2fba-4e5b-afa0-d68975a09b1e" />
<img width="1734" height="1369" alt="dreamseeker_okt9acTxa1" src="https://github.com/user-attachments/assets/dfad496b-1d3f-4a34-9a74-545ef44ddeee" />
<img width="1734" height="1369" alt="dreamseeker_umIYvK0Taf" src="https://github.com/user-attachments/assets/a65d8a72-3cfd-4afe-821e-4fc4939163a4" />
<img width="1734" height="1369" alt="dreamseeker_kVY9q8UkOh" src="https://github.com/user-attachments/assets/f74b7b24-e4a8-4e7f-900c-9218615d64ac" />
<img width="1734" height="1369" alt="dreamseeker_Q5t01XDFAt" src="https://github.com/user-attachments/assets/1bfd9b23-8577-4f32-a0e2-5620128293c1" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Changed Armory Stock
map: Added bathroom to Millennium Tower 3rd floor, and a washing machine to the supply closet outside the conference room
map: hid blood around Millennium Tower from Tower Employees in a care room on the 1st floor
map: added a janitorial closet to the 1st floor
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
